### PR TITLE
ENG-529 introducing connection validation in JBoss containers

### DIFF
--- a/entando-eap71-base/Dockerfile
+++ b/entando-eap71-base/Dockerfile
@@ -5,7 +5,7 @@ ARG ENTANDO_IMAGE_VERSION
 FROM entando/entando-base-common:$ENTANDO_IMAGE_VERSION AS entando-common-base
 
 #FROM registry.access.redhat.com/jboss-eap-7/eap71-openshift:1.3
-FROM registry.connect.redhat.com/entando/entando-eap71-openshift-imagick:latest
+FROM registry.redhat.io/jboss-eap-7/eap71-openshift:latest
 ARG ENTANDO_VERSION
 ARG MAVEN_MIRROR_FOR_DOCKER_BUILDS
 LABEL maintainer="Ampie Barnard <a.barnard@entando.com>" \

--- a/entando-eap71-clustered-base/Dockerfile
+++ b/entando-eap71-clustered-base/Dockerfile
@@ -16,19 +16,27 @@ COPY --chown=185:0 ./standalone-openshift.xml /opt/eap/standalone/configuration
 
 ENV PORTDB_NONXA="true" \
     PORTDB_JTA="false" \
-    PORTDB_URL="" \
+    PORTDB_URL="jdbc:derby:/entando-data/databases/entandoPort;create=true" \
     PORTDB_JNDI="java:jboss/datasources/entandoPortDataSource" \
-    PORTDB_DRIVER="postgresql" \
+    PORTDB_DRIVER="derby" \
     PORTDB_USERNAME="agile" \
     PORTDB_PASSWORD="agile" \
-    PORTDB_SERVICE_HOST="postgresql" \
-    PORTDB_SERVICE_PORT="5432" \
+    PORTDB_SERVICE_HOST="dummy" \
+    PORTDB_SERVICE_PORT="1234" \
+    PORTDB_BACKGROUND_VALIDATION="true" \
+    PORTDB_EXCEPTION_SORTER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter" \
+    PORTDB_BACKGROUND_VALIDATION_MILLIS="60000" \
+    PORTDB_CONNECTION_CHECKER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker" \
     SERVDB_NONXA="true" \
     SERVDB_JTA="false" \
-    SERVDB_URL="" \
+    SERVDB_URL="jdbc:derby:/entando-data/databases/entandoServ;create=true" \
     SERVDB_JNDI="java:jboss/datasources/entandoServDataSource" \
-    SERVDB_DRIVER="postgresql" \
+    SERVDB_DRIVER="derby" \
     SERVDB_USERNAME="agile" \
     SERVDB_PASSWORD="agile" \
-    SERVDB_SERVICE_HOST="postgresql" \
-    SERVDB_SERVICE_PORT="5432"
+    SERVDB_SERVICE_HOST="dummy" \
+    SERVDB_SERVICE_PORT="1234" \
+    SERVDB_BACKGROUND_VALIDATION="true" \
+    SERVDB_BACKGROUND_VALIDATION_MILLIS="60000" \
+    SERVDB_CONNECTION_CHECKER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker" \
+    SERVDB_EXCEPTION_SORTER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter"

--- a/entando-wildfly12-base/Dockerfile
+++ b/entando-wildfly12-base/Dockerfile
@@ -32,6 +32,8 @@ ENV PORTDB_NONXA="true" \
     PORTDB_PASSWORD="agile" \
     PORTDB_SERVICE_HOST="dummy" \
     PORTDB_SERVICE_PORT="1527" \
+    PORTDB_CONNECTION_CHECKER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker" \
+    PORTDB_EXCEPTION_SORTER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter" \
     SERVDB_NONXA="true" \
     SERVDB_JTA="false" \
     SERVDB_URL="jdbc:derby:/entando-data/databases/entandoServ;create=true" \
@@ -41,6 +43,8 @@ ENV PORTDB_NONXA="true" \
     SERVDB_PASSWORD="agile" \
     SERVDB_SERVICE_HOST="dummy" \
     SERVDB_SERVICE_PORT="1527" \
+    SERVDB_CONNECTION_CHECKER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullValidConnectionChecker" \
+    SERVDB_EXCEPTION_SORTER="org.jboss.jca.adapters.jdbc.extensions.novendor.NullExceptionSorter" \
     PREPARE_DATA="true" \
     DB_ENVIRONMENT="production" \
     JBOSS_HOME="/wildfly/" \

--- a/entando-wildfly12-base/contrib/wildfly-configuration/standalone.xml
+++ b/entando-wildfly12-base/contrib/wildfly-configuration/standalone.xml
@@ -150,6 +150,15 @@
             <user-name>${env.PORTDB_USERNAME}</user-name>
             <password>${env.PORTDB_PASSWORD}</password>
           </security>
+          <validation>
+            <valid-connection-checker>${env.PORTDB_CONNECTION_CHECKER}</valid-connection-checker>
+            <exception-sorter>${env.PORTDB_EXCEPTION_SORTER}</exception-sorter>
+            <background-validation>true</background-validation>
+            <background-validation-millis>60000</background-validation-millis>
+          </validation>
+          <pool>
+            <flush-strategy>IdleConnections</flush-strategy>
+          </pool>
         </datasource>
         <datasource jndi-name="${env.SERVDB_JNDI}" enabled="true" use-java-context="true" pool-name="entandoDbServDataSource" use-ccm="true">
           <connection-url>${env.SERVDB_URL}</connection-url>
@@ -158,6 +167,15 @@
             <user-name>${env.SERVDB_USERNAME}</user-name>
             <password>${env.SERVDB_PASSWORD}</password>
           </security>
+          <validation>
+            <valid-connection-checker>${env.SERVDB_CONNECTION_CHECKER}</valid-connection-checker>
+            <exception-sorter>${env.SERVDB_EXCEPTION_SORTER}</exception-sorter>
+            <background-validation>true</background-validation>
+            <background-validation-millis>60000</background-validation-millis>
+          </validation>
+          <pool>
+            <flush-strategy>IdleConnections</flush-strategy>
+          </pool>
         </datasource>
         <drivers>
           <!-- ##ORACLE_DRIVER## -->


### PR DESCRIPTION
This PR introduces a connection checker and exception sorter for each datasource to ensure that JBoss knows to reconnect with an external database once a connection fails the validation check.