### PR TITLE
ENG-2633 Updated Jetty db migration parameter

### DIFF
--- a/entando-base-common/entando-common/build-jetty-command.sh
+++ b/entando-base-common/entando-common/build-jetty-command.sh
@@ -65,7 +65,7 @@ cp -Rf protected /entando-data/
 
 
 cp /jetty-runner/jetty.xml .
-export JETTY_COMMAND="java -Ddb.startup.check=true \
+export JETTY_COMMAND="java -Ddb.migration.strategy=auto \
     -Ddb.restore.enabled=true \
     -Dentando.web.context="${ENTANDO_WEB_CONTEXT}" \
     -Dprofile.datasource.jndiname.servdb=${SERVDB_JNDI} \

--- a/entando-eap73-clustered-base/Dockerfile
+++ b/entando-eap73-clustered-base/Dockerfile
@@ -1,7 +1,7 @@
 # This image provides a very lightweight base for building and running Entando
 # EAP based applications with an embedded Derby db.
 # It builds using maven and runs the resulting artifacts on EAP
-FROM entando/entando-base-common:6.3.2 AS entando-base-common
+FROM entando/entando-base-common:6.3.3 AS entando-base-common
 
 FROM registry.redhat.io/jboss-eap-7/eap73-openjdk8-openshift-rhel7:7.3.6-1
 

--- a/entando-wildfly17-base/Dockerfile
+++ b/entando-wildfly17-base/Dockerfile
@@ -1,6 +1,6 @@
 # This image provides a base for building and running Entando WildFly based applications.
 # It builds using maven and runs the resulting artifacts on WildFly 17.0.0 Final
-FROM entando/entando-base-common:6.3.2 AS entando-base-common
+FROM entando/entando-base-common:6.3.3 AS entando-base-common
 
 FROM quay.io/wildfly/wildfly-centos7:17.0
 LABEL maintainer="Ampie Barnard <a.barnard@entando.com>" \

--- a/sample-maven-project/pom.xml
+++ b/sample-maven-project/pom.xml
@@ -977,8 +977,8 @@
                             <value>${entando.version}</value>
                         </systemProperty>
                         <systemProperty>
-                            <name>db.startup.check</name>
-                            <value>true</value>
+                            <name>db.migration.strategy</name>
+                            <value>auto</value>
                         </systemProperty>
                         <systemProperty>
                             <name>db.restore.enabled</name>

--- a/sample-maven-project/src/test/config/conf/systemParams.properties
+++ b/sample-maven-project/src/test/config/conf/systemParams.properties
@@ -56,7 +56,7 @@ jacms.attachResource.allowedExtensions=pdf,xls,doc,ppt,txt,rtf,sxw,sxc,odt,ods,o
 ## Database configuration
 
 ## check db schema on startup - true|false
-db.startup.check=true
+db.migration.strategy=auto
 
 db.restore.enabled=true
 


### PR DESCRIPTION
Current base images versions are:

```
entando-base-common:6.3.2
entando-wildfly17-base:6.3.7
entando-eap73-clustered-base:6.3.7
```
After merging the PR I will manually build and push to Dockerhub:
```
entando-base-common:6.3.3
entando-wildfly17-base:6.3.8
entando-eap73-clustered-base:6.3.8
```
Once the new images will be available I will create another PR to modify Dockerfiles in [entando-de-app](https://github.com/entando-k8s/entando-de-app)